### PR TITLE
Prevent launching debug jobs if no rule was found.

### DIFF
--- a/src/UI.cpp
+++ b/src/UI.cpp
@@ -1125,6 +1125,8 @@ void gDrawDebugWindow()
 		return;
 	}
 
+	bool no_rules_found = gCookingSystem.mCommands.Size() == 0;
+	ImGui::BeginDisabled(no_rules_found);
 	if (ImGui::Button("Cook 100"))
 	{
 		int num_commands  = gCookingSystem.mCommands.Size();
@@ -1147,6 +1149,13 @@ void gDrawDebugWindow()
 			gCookingSystem.ForceCook(gCookingSystem.mCommands[i].mID);
 		}
 	}
+	if (no_rules_found)
+	{
+		ImGui::SameLine();
+		ImGui::AlignTextToFramePadding();
+		ImGui::Text("No rules found");
+	}
+	ImGui::EndDisabled();
 
 	ImGui::Checkbox("Slow mode", &gCookingSystem.mSlowMode);
 	ImGui::Checkbox("Cause random Cooking errors", &gDebugFailCookingRandomly);

--- a/src/UI.cpp
+++ b/src/UI.cpp
@@ -1125,8 +1125,8 @@ void gDrawDebugWindow()
 		return;
 	}
 
-	bool no_rules_found = gCookingSystem.mCommands.Size() == 0;
-	ImGui::BeginDisabled(no_rules_found);
+	bool no_command_found = gCookingSystem.mCommands.Size() == 0;
+	ImGui::BeginDisabled(no_command_found);
 	if (ImGui::Button("Cook 100"))
 	{
 		int num_commands  = gCookingSystem.mCommands.Size();
@@ -1149,11 +1149,11 @@ void gDrawDebugWindow()
 			gCookingSystem.ForceCook(gCookingSystem.mCommands[i].mID);
 		}
 	}
-	if (no_rules_found)
+	if (no_command_found)
 	{
 		ImGui::SameLine();
 		ImGui::AlignTextToFramePadding();
-		ImGui::Text("No rules found");
+		ImGui::Text("No commands found");
 	}
 	ImGui::EndDisabled();
 


### PR DESCRIPTION
Here's a small fix I got by randomly doing stuff when discovering the tool: trying to launch jobs where no rule was found would trigger a division by zero when trying to grab a random rule.

Feel free to tweak the code to fit your own UI/UX practices, while my patch does the trick, I'm not sure if that'd be the best  or most future-proofed solution.

Have a nice day.