### PR TITLE
Rewrite of of GNU Make-like depfile parsing.

### DIFF
--- a/src/DepFile.cpp
+++ b/src/DepFile.cpp
@@ -208,7 +208,7 @@ static bool sParseMakeDepFile(FileID inDepFileID, StringView inDepFileContent, s
 			// Last line might also end with a linefeed (or nothing).
 			constexpr StringView cLastLineEnd = "\n\r";
 			path_end = dep_file_content.find_first_of(cLastLineEnd);
-			next_path = path_end + cLastLineEnd.size();
+			next_path = path_end + 1;
 
 			if (path_end == StringView::npos)
 				next_path = dep_file_content.size();

--- a/src/DepFile.cpp
+++ b/src/DepFile.cpp
@@ -56,37 +56,37 @@ static bool sIsSpace(char inChar)
 
 // glslang and GNU make expects a series of paths on a single line.
 // Spaces in paths are escaped with backslashes.
-static StringView sExtractFirstPath(StringView line)
+static StringView sExtractFirstPath(StringView inLine)
 {
-	bool escapingNextCharacter = false;
+	bool escaping_next_character = false;
 	// Trim spaces before processing.
-	while (!line.empty() && sIsSpace(line[0]))
+	while (!inLine.empty() && sIsSpace(inLine[0]))
 	{
-		line = line.substr(1);
+		inLine.remove_prefix(1);
 	}
-	while (!line.empty() && sIsSpace(line[line.size() - 1]))
+	while (!inLine.empty() && sIsSpace(inLine[inLine.size() - 1]))
 	{
-		line = line.substr(0, line.size() - 1);
+		inLine.remove_suffix(1);
 	}
 
-	StringView remaining = line;
+	StringView remaining = inLine;
 	while (!remaining.empty())
 	{
 		char c = remaining[0];
-		if (escapingNextCharacter)
+		if (escaping_next_character)
 		{
-			escapingNextCharacter = false;
+			escaping_next_character = false;
 		}
 		else if (c == '\\')
 		{
-			escapingNextCharacter = true;
+			escaping_next_character = true;
 		}
 		else if(sIsSpace(c))
-			return line.substr(0, remaining.data() - line.data());
+			return inLine.substr(0, remaining.data() - inLine.data());
 
 		remaining = remaining.substr(1);
 	}
-	return line;
+	return inLine;
 }
 
 REGISTER_TEST("ExtractFirstPath")
@@ -120,7 +120,7 @@ static TempPath sCleanupPath(StringView line)
 	return cleaned_path;
 }
 
-// Probably a very shitty parser. Just good enough for parsing dep files from DXC.
+// Barebones GNU Make-like dependency file parser. 
 static bool sParseMakeDepFile(FileID inDepFileID, StringView inDepFileContent, std::vector<FileID>& outInputs)
 {
 	StringView dep_file_content = inDepFileContent;

--- a/src/DepFile.cpp
+++ b/src/DepFile.cpp
@@ -120,6 +120,16 @@ static TempPath sCleanupPath(StringView line)
 	return cleaned_path;
 }
 
+REGISTER_TEST("CleanupPath")
+{
+	TEST_TRUE(sCleanupPath("./file.txt").AsStringView() == "./file.txt");
+	// glslang escape special characters in paths.
+	TEST_TRUE(sCleanupPath(R"(C\:\\some\\escaped\\path)").AsStringView() == R"(C:\some\escaped\path)");
+	TEST_TRUE(sCleanupPath(R"(C:\\path\ with\ space\\should\ work.txt)").AsStringView() == R"(C:\path with space\should work.txt)");
+	// but handling those shouldn't break standard paths.
+	TEST_TRUE(sCleanupPath(R"(C:\Windows\path32\command.com)").AsStringView() == R"(C:\Windows\path32\command.com)");
+};
+
 // Barebones GNU Make-like dependency file parser. 
 static bool sParseMakeDepFile(FileID inDepFileID, StringView inDepFileContent, std::vector<FileID>& outInputs)
 {


### PR DESCRIPTION
Hello.

I'm currently halfway writing the GNU Make/GCC-like dependency file parsing algorithm in order to fix #3.

It still needs more polish, more specifically code style and tests, but I could make it work with depfiles from softwares such as `glslang` (which does the same kind of depfile than `glslc` but properly escape file paths with spaces.

Have a nice day.