### PR TITLE
Recreate the notification icon on failure to add it.

### DIFF
--- a/src/Notifications.cpp
+++ b/src/Notifications.cpp
@@ -26,6 +26,14 @@ void gNotifInit(void* inHwnd)
 	gStringCopy(nid.szTip, gApp.mMainWindowTitle);
 
 	bool ret = Shell_NotifyIconA(NIM_ADD, &nid);
+	// If the program is killed without letting it clean up its icon, the next launch's add will fail.
+	// Deleting that "zombie" icon first before recreating it allows to "refresh" the icon ourselves.
+	if (!ret)
+	{
+		ret = Shell_NotifyIconA(NIM_DELETE, &nid);
+		gAssert(ret);
+		ret = Shell_NotifyIconA(NIM_ADD, &nid);
+	}
 	gAssert(ret);
 
 	// NOTIFYICON_VERSION_4 is prefered


### PR DESCRIPTION
Hello.

This is one solution to close #5, if we assume that the GUID will be effecitvely unique, we're able to delete and recreate the notification icon and continue as usual.

Until we get a "cleaner" solution or want to switch to [using different GUIDs until one works](https://github.com/jlaumon/AssetCooker/issues/5#issuecomment-2205211231), I believe this method would be satisfactory enough.

SIdenote : I saw some software already using multiple GUIDs, like [Live++](https://liveplusplus.tech/) in some situations.