### PR TITLE
Fix crashes when copying strings containing format characters to the clipboard 

### DIFF
--- a/src/UI.cpp
+++ b/src/UI.cpp
@@ -382,8 +382,8 @@ void gDrawFileInfo(const FileInfo& inFile, FileContext inContext = {})
 		if (ImGui::Button("Copy Path"))
 		{
 			ImGui::LogToClipboard();
-			ImGui::LogText(inFile.GetRepo().mRootPath.AsCStr());
-			ImGui::LogText(inFile.mPath.AsCStr());
+			ImGui::LogText("%s", inFile.GetRepo().mRootPath.AsCStr());
+			ImGui::LogText("%s", inFile.mPath.AsCStr());
 			ImGui::LogFinish();
 		}
 
@@ -904,7 +904,7 @@ void gDrawSelectedCookingLogEntry()
 		if (command_line)
 		{
 			ImGui::LogToClipboard();
-			ImGui::LogText(command_line->c_str());
+			ImGui::LogText("%s", command_line->c_str());
 			ImGui::LogFinish();
 		}
 	}


### PR DESCRIPTION
`ImGui::LogText` expects a format string, so if you pass it a string that coincidentally contains format characters then it's going to try to format the string with some varargs that don't actually exist, which for me just crashed.

I originally only hit issues when coping a command line containing `%` to the clipboard, but I think it makes sense to update the two other uses as well, since they'd also cause problems if you had a filepath that contained `%` instead (which I think is a valid filename character?)