### PR TITLE
Implemented a right-click menu for notification icon.

### DIFF
--- a/src/App.h
+++ b/src/App.h
@@ -60,6 +60,7 @@ struct App
 
 	String                          mMainWindowTitle       = "Asset Cooker";
 	void*                           mMainWindowHwnd        = nullptr;
+	void*                           mNotifMenuHmenu        = nullptr;
 	bool                            mMainWindowIsMinimized = false;
 	bool                            mExitRequested         = false;
 	bool                            mExitReady             = false;

--- a/src/CookingSystem.h
+++ b/src/CookingSystem.h
@@ -332,10 +332,6 @@ struct CookingSystem : NoCopy
 	CookingLogEntry&                      AllocateCookingLogEntry(CookingCommandID inCommandID);
 
 	bool                                  mSlowMode = false; // Slows down cooking, for debugging.
-
-	// Experimental, used by main.cpp
-	void                                  QueueErroredCommands();
-
 private:
 	friend struct CookingCommand;
 	friend void gDrawCookingQueue();
@@ -350,6 +346,7 @@ private:
 	void                                  AddTimeOut(CookingLogEntry* inLogEntry);
 	void                                  TimeOutUpdateThread(std::stop_token inStopToken);
 	void                                  QueueDirtyCommands();
+	void                                  QueueErroredCommands();
 
 	VMemArray<CookingRule>                mRules      = { 1024ull * 1024, 4096 };
 	StringPool                            mStringPool = { 64ull * 1024 };

--- a/src/CookingSystem.h
+++ b/src/CookingSystem.h
@@ -332,6 +332,10 @@ struct CookingSystem : NoCopy
 	CookingLogEntry&                      AllocateCookingLogEntry(CookingCommandID inCommandID);
 
 	bool                                  mSlowMode = false; // Slows down cooking, for debugging.
+
+	// Experimental, used by main.cpp
+	void                                  QueueErroredCommands();
+
 private:
 	friend struct CookingCommand;
 	friend void gDrawCookingQueue();
@@ -346,7 +350,6 @@ private:
 	void                                  AddTimeOut(CookingLogEntry* inLogEntry);
 	void                                  TimeOutUpdateThread(std::stop_token inStopToken);
 	void                                  QueueDirtyCommands();
-	void                                  QueueErroredCommands();
 
 	VMemArray<CookingRule>                mRules      = { 1024ull * 1024, 4096 };
 	StringPool                            mStringPool = { 64ull * 1024 };

--- a/src/Notifications.h
+++ b/src/Notifications.h
@@ -7,9 +7,6 @@
 #include "Strings.h"
 
 constexpr uint32 cNotifCallbackID = 0x8001; //  ie. WM_APP + 1
-// Not used yet but could be used as an ID mask to dispatch events.
-[[maybe_unused]]
-constexpr uint32 cNotifMenuId = 0x8100;
 constexpr uint32 cNotifMenuExit = 0x8101;
 constexpr uint32 cNotifMenuPauseCooking = 0x8102;
 

--- a/src/Notifications.h
+++ b/src/Notifications.h
@@ -7,6 +7,11 @@
 #include "Strings.h"
 
 constexpr uint32 cNotifCallbackID = 0x8001; //  ie. WM_APP + 1
+// Not used yet but could be used as an ID mask to dispatch events.
+[[maybe_unused]]
+constexpr uint32 cNotifMenuId = 0x8100;
+constexpr uint32 cNotifMenuExit = 0x8101;
+constexpr uint32 cNotifMenuCookErrored = 0x8102;
 
 enum class NotifType
 {

--- a/src/Notifications.h
+++ b/src/Notifications.h
@@ -11,7 +11,7 @@ constexpr uint32 cNotifCallbackID = 0x8001; //  ie. WM_APP + 1
 [[maybe_unused]]
 constexpr uint32 cNotifMenuId = 0x8100;
 constexpr uint32 cNotifMenuExit = 0x8101;
-constexpr uint32 cNotifMenuCookErrored = 0x8102;
+constexpr uint32 cNotifMenuPauseCooking = 0x8102;
 
 enum class NotifType
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -564,9 +564,9 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 			HMENU hMenu = CreatePopupMenu();
 			gApp.mNotifMenuHmenu = hMenu;
 			bool isCookingPaused = gCookingSystem.IsCookingPaused(); 
-			ret = InsertMenu(hMenu, 0, MF_BYPOSITION | MF_STRING, cNotifMenuPauseCooking,  isCookingPaused ? L"Resume cooking" : L"Pause cooking");
+			ret = InsertMenuA(hMenu, 0, MF_BYPOSITION | MF_STRING, cNotifMenuPauseCooking,  isCookingPaused ? "Resume cooking" : "Pause cooking");
 			gAssert(ret);
-			ret = InsertMenu(hMenu, -1, MF_BYPOSITION | MF_STRING, cNotifMenuExit, L"Exit");
+			ret = InsertMenuA(hMenu, -1, MF_BYPOSITION | MF_STRING, cNotifMenuExit, "Exit");
 			gAssert(ret);
 			ret = TrackPopupMenu(hMenu, TPM_LEFTALIGN | TPM_LEFTBUTTON | TPM_BOTTOMALIGN, cursorPosition.x, cursorPosition.y, 0, hWnd, nullptr);
 			gAssert(ret);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -525,8 +525,8 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 	case WM_COMMAND:
 		switch (wParam)
 		{
-		case cNotifMenuCookErrored:
-			gCookingSystem.QueueErroredCommands();
+		case cNotifMenuPauseCooking:
+			gCookingSystem.SetCookingPaused(!gCookingSystem.IsCookingPaused());
 			break;
 			// Exit
 		case cNotifMenuExit:
@@ -563,7 +563,8 @@ LRESULT WINAPI WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
 			HMENU hMenu = CreatePopupMenu();
 			gApp.mNotifMenuHmenu = hMenu;
-			ret = InsertMenu(hMenu, 0, MF_BYPOSITION | MF_STRING, cNotifMenuCookErrored, L"Cook errored");
+			bool isCookingPaused = gCookingSystem.IsCookingPaused(); 
+			ret = InsertMenu(hMenu, 0, MF_BYPOSITION | MF_STRING, cNotifMenuPauseCooking,  isCookingPaused ? L"Resume cooking" : L"Pause cooking");
 			gAssert(ret);
 			ret = InsertMenu(hMenu, -1, MF_BYPOSITION | MF_STRING, cNotifMenuExit, L"Exit");
 			gAssert(ret);


### PR DESCRIPTION
Hello.

I quickly drafted a right-click menu for the notification icon to quickly have an exit option. I also threw an option to force errored cooking commands as I sometimes get to retrigger those after a few errors.
![image](https://github.com/user-attachments/assets/5162b371-2dc9-4130-93cb-6e476359cd4e)

This is more a draft than a serious PR but if you're interested into this PR, I could write a less hacky-looking solution than the one provided here.

Have a nice day.