### PR TITLE
Added option to start AssetCooker as minimzed/hidden.

### DIFF
--- a/src/App.h
+++ b/src/App.h
@@ -72,6 +72,7 @@ struct App
 	String                          mInitError;
 
 	bool                            mHideWindowOnMinimize       = true; // Hide the window when minimizing it.
+	bool                            mStartMinimized             = false; // Start with the window minimized (or hidden if mHideWindowOnMinimize is set).
 	NotifEnabled                    mEnableNotifOnHideWindow    = NotifEnabled::Always; // Show a notification when the window is hidden saying that Asset Cooker is still running.
 	NotifEnabled                    mEnableNotifOnCookingFinish = NotifEnabled::WhenMinimized; // Show a notification when cooking finishes.
 	NotifEnabled                    mEnableNotifOnCookingError  = NotifEnabled::Always; // Show a notification when a cooking error occurs (even if cooking isn't finished yet).

--- a/src/UI.cpp
+++ b/src/UI.cpp
@@ -202,6 +202,7 @@ void gDrawMainMenuBar()
 		if (ImGui::BeginMenu("Settings"))
 		{
 			ImGui::MenuItem("Hide Window On Minimize", nullptr, &gApp.mHideWindowOnMinimize);
+			ImGui::MenuItem("Start with the Window Minimized", nullptr, &gApp.mStartMinimized);
 			sMenuEnum("Enable Notif On Cooking Finish", gApp.mEnableNotifOnCookingFinish);
 			sMenuEnum("Enable Notif On Cooking Error", gApp.mEnableNotifOnCookingError);
 			sMenuEnum("Enable Notif Sound", gApp.mEnableNotifSound);

--- a/src/UserPreferencesReader.cpp
+++ b/src/UserPreferencesReader.cpp
@@ -39,6 +39,13 @@ void gReadUserPreferencesFile(StringView inPath)
 			gCookingSystem.SetCookingPaused(start_paused);
 	}
 
+	// Start minimized (or hidden to tray icon)
+	{
+		bool start_minimized = gApp.mStartMinimized;
+		if (reader.TryRead("StartMinimized", start_minimized))
+			gApp.mStartMinimized = start_minimized;
+	}
+
 	// Number of Cooking Threads.
 	{
 		int num_cooking_threads = 0;
@@ -99,6 +106,7 @@ void gWriteUserPreferencesFile(StringView inPath)
 	toml::table prefs_toml;
 
 	prefs_toml.insert("StartPaused", gCookingSystem.IsCookingPaused());
+	prefs_toml.insert("StartMinimized", gApp.mStartMinimized);
 	prefs_toml.insert("NumCookingThreads", gCookingSystem.GetCookingThreadCount());
 	prefs_toml.insert("LogFSActivity", std::string_view(gToStringView(gApp.mLogFSActivity).AsCStr()));
 	prefs_toml.insert("UIScale", gUIGetUserScale());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -248,7 +248,7 @@ int WinMain(
 		gAppFatalError("Failed to create D3D device - %s", GetLastErrorString().AsCStr());
 
 	// Show the window
-	::ShowWindow(hwnd, SW_SHOWDEFAULT);
+	::ShowWindow(hwnd, gApp.mStartMinimized ? SW_SHOWMINIMIZED : SW_SHOWDEFAULT);
 	::UpdateWindow(hwnd);
 
 	// Setup Dear ImGui context


### PR DESCRIPTION
Closes #16 . Quoting for reference:

> Is there a need for AssetCooker to be able to start hidden or minimized? For myself I tend of consider daemon-like programs as background and want them out of my way until I need them thus I implemented it on my side.

Have a nice day.