### PR TITLE
Fixed recooking everything when there's an invalid repo in the cache

### DIFF
--- a/src/FileSystem.h
+++ b/src/FileSystem.h
@@ -272,16 +272,17 @@ struct FileRepo : NoCopy
 	};
 	void                ScanFile(FileInfo& ioFile, RequestedAttributes inRequestedAttributes);
 
-	uint32				mIndex = 0;				// The index of this repo.
-	StringView			mName;					// A named used to identify the repo.
-	StringView			mRootPath;				// Absolute path to the repo. Starts with the drive letter, ends with a slash.
-	FileDrive&			mDrive;					// The drive this repo is on.
-	FileID				mRootDirID;				// The FileID of the root dir.
-	bool				mNoOrphanFiles = false; // True when the repo is not supposed to contain orphan files (files that are neither inputs or outputs of any command).
+	uint32				mIndex = 0;				  // The index of this repo.
+	StringView			mName;					  // A named used to identify the repo.
+	StringView			mRootPath;				  // Absolute path to the repo. Starts with the drive letter, ends with a slash.
+	FileDrive&			mDrive;					  // The drive this repo is on.
+	FileID				mRootDirID;				  // The FileID of the root dir.
+	bool				mNoOrphanFiles	 = false; // True when the repo is not supposed to contain orphan files (files that are neither inputs or outputs of any command).
+	bool				mLoadedFromCache = false; // True when the content of this repo was loaded from the cache.
 
-	VMemArray<FileInfo> mFiles;					// All the files in this repo.
+	VMemArray<FileInfo> mFiles;					  // All the files in this repo.
 
-	StringPool			mStringPool;			// Pool for storing all the paths.
+	StringPool			mStringPool;			  // Pool for storing all the paths.
 };
 
 
@@ -305,7 +306,6 @@ struct FileDrive : NoCopy
 	uint64                 mUSNJournalID = 0; // Journal ID, needed to query the USN journal.
 	USN                    mFirstUSN     = 0;
 	USN                    mNextUSN      = 0;
-	bool                   mLoadedFromCache = false;
 	Vector<FileRepo*>      mRepos;
 
 	using FilesByRefNumberMap = VMemHashMap<FileRefNumber, FileID>;

--- a/src/UI.cpp
+++ b/src/UI.cpp
@@ -1405,8 +1405,13 @@ void gDrawDebugWindow()
 	for (const FileRepo& repo : gFileSystem.GetRepos())
 	{
 		ImGui::PushID(&repo);
-		if (ImGui::CollapsingHeader(gTempFormat("%s (%s) - %d Files##Repo", repo.mName.AsCStr(), repo.mRootPath.AsCStr(), repo.mFiles.Size())))
+		if (ImGui::CollapsingHeader(gTempFormat("Repo %s (%s) - %d Files%s##Repo", 
+			repo.mName.AsCStr(), 
+			repo.mRootPath.AsCStr(), 
+			repo.mFiles.Size(), 
+			repo.mLoadedFromCache ? " (loaded from cache)" : "")))
 		{
+
 			ImGuiListClipper clipper;
 			clipper.Begin(repo.mFiles.Size());
 			while (clipper.Step())


### PR DESCRIPTION
Further improvement after 60afcd3, we can use the cache even if there's an invalid repo as it just gets rescanned if it still exists.

Fixes 29