### PR TITLE
Added -no_ui command line option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -206,6 +206,12 @@ Command Variables also support a slice syntax similar to Python (eg. `{ File[1:3
 | `{ File[:-6] }`        | `albedo`           |
 | `{ File[1:1000] }`     | `rick_albedo`      |
 
+## Command Line Options
+
+- `-working_dir some/path`: Use `some/path` as the working directory (Current Directory in Windows terminology). The Config File is read from there, all relative paths are relative to there. Accepts both relative and absolute paths. 
+- `-no_ui`: Run without UI, cook everything then exit. Exit code is 0 on success. 
+- `-test`: Run unit tests then exit. Exit code is 0 on success. Note: Does nothing when Asset Cooker is compiled in Release mode (tests are disabled). 
+
 ## Contributing 
 Open an issue before doing a pull request. It's a hobby project, please be nice.
 

--- a/src/App.h
+++ b/src/App.h
@@ -11,6 +11,7 @@
 #include "Notifications.h"
 
 #include <Bedrock/String.h>
+#include <Bedrock/Event.h>
 
 enum class LogLevel : uint8
 {
@@ -52,7 +53,6 @@ struct App
 
 	void RequestExit();
 	bool IsExitRequested() const;
-	bool IsExitReady() const;
 
 	bool HasInitError() const { return !mInitError.Empty(); }
 	void SetInitError(StringView inText) { mInitError = inText; }
@@ -69,8 +69,8 @@ struct App
 	void*							mMainWindowHwnd		   = nullptr;
 	void*							mNotifMenuHmenu		   = nullptr;
 	bool							mMainWindowIsMinimized = false;
-	bool							mExitRequested		   = false;
-	bool							mExitReady			   = false;
+	bool							mNoUI				   = false;					 // If true, run without UI and automatically exit when cooking is finished.
+	Event							mExitRequestedEvent	   = { Event::ManualReset }; // Event that gets set when exit is requested.
 	String							mConfigFilePath		   = "config.toml";
 	String							mUserPrefsFilePath	   = "prefs.toml";
 	String							mRuleFilePath		   = "rules.toml";

--- a/src/CookingSystem.h
+++ b/src/CookingSystem.h
@@ -236,7 +236,7 @@ struct CookingThreadsQueue : CookingQueue
 {
 	void                    Push(CookingCommandID inCommandID, PushPosition inPosition = PushPosition::Back);
 	CookingCommandID        Pop();
-	void                    FinishedCooking(CookingCommandID inCommandID);
+	void                    FinishedCooking(const CookingLogEntry& inLogEntry);
 
 	void                    RequestStop();
 
@@ -280,8 +280,11 @@ struct CookingSystem : NoCopy
 	bool                                  IsCookingPaused() const { return mCookingPaused; }
 	void                                  SetCookingThreadCount(int inThreadCount) { mWantedCookingThreadCount = inThreadCount; }
 	int                                   GetCookingThreadCount() const { return mWantedCookingThreadCount; }
+	int									  GetCookingErrorCount() const { return mCookingErrors.Load(); }
 
 	int                                   GetCommandCount() const { return mCommands.Size(); } // Total number of commands, for debug/display.
+	int									  GetDirtyCommandCount() const { return mCommandsDirty.GetSize(); }
+	int									  GetCookedCommandCount() const { return mCookingLog.Size(); }
 
 	void                                  QueueUpdateDirtyStates(FileID inFileID);
 	void                                  QueueUpdateDirtyState(CookingCommandID inCommandID);


### PR DESCRIPTION
In No-UI mode, Asset Cooker behaves like a console application. It cooks everything then exits.

If everything went well, its exit code is 0. If there are cooking errors, or if it is forced to exit before everything is cooked, its exit code is != 0 (always 1 currently).

This should be useful for CI/CD.

![image](https://github.com/user-attachments/assets/8760d263-d03d-44ab-bd92-b0aaf9368b2d)
