### PR TITLE
Add basic support for output log colors from ANSI escape sequences

### DIFF
--- a/src/CookingSystem.cpp
+++ b/src/CookingSystem.cpp
@@ -1248,7 +1248,7 @@ void CookingSystem::CookCommand(CookingCommand& ioCommand, CookingThread& ioThre
 
 	// Store the log output.
 	log_entry.mOutput = output_str.AsStringView();
-	gPreprocessStringViewFormatting(log_entry.mOutput, log_entry.mOutputFormatSpans);
+	gParseANSIColors(log_entry.mOutput, log_entry.mOutputFormatSpans);
 
 	if (!success)
 	{

--- a/src/CookingSystem.cpp
+++ b/src/CookingSystem.cpp
@@ -1248,6 +1248,7 @@ void CookingSystem::CookCommand(CookingCommand& ioCommand, CookingThread& ioThre
 
 	// Store the log output.
 	log_entry.mOutput = output_str.AsStringView();
+	gPreprocessStringViewFormatting(log_entry.mOutput, log_entry.mOutputFormatSpans);
 
 	if (!success)
 	{
@@ -1293,6 +1294,8 @@ void CookingSystem::CleanupCommand(CookingCommand& ioCommand, CookingThread& ioT
 	}
 
 	log_entry.mOutput       = output_str.AsStringView();
+	log_entry.mOutputFormatSpans.ClearAndFreeMemory();
+
 	log_entry.mTimeEnd      = gGetSystemTimeAsFileTime();
 
 	if (error)

--- a/src/CookingSystem.h
+++ b/src/CookingSystem.h
@@ -133,6 +133,7 @@ struct CookingLogEntry
 	FileTime                  mTimeStart;
 	FileTime                  mTimeEnd;		// Unsafe to read unless CookingState is > Cooking. TODO add getters that assert this
 	StringView                mOutput;		// Unsafe to read unless CookingState is > Cooking.
+	Vector<FormatSpan>        mOutputFormatSpans; // Unsafe to read unless CookingState is > Cooking.
 };
 
 

--- a/src/Strings.cpp
+++ b/src/Strings.cpp
@@ -110,8 +110,7 @@ void gParseANSIColors(StringView inStr, Vector<FormatSpan>& outSpans)
 			if (outSpans.Size() > 0 && cursor < inStr.Size())
 			{
 				FormatSpan span;
-				span.mBegin = inStr.AsCStr() + cursor;
-				span.mEnd	= inStr.End();
+				span.mSpan	= inStr.SubStr(cursor);
 				span.mColor = current_color;
 				outSpans.PushBack(span);
 			}
@@ -133,8 +132,7 @@ void gParseANSIColors(StringView inStr, Vector<FormatSpan>& outSpans)
 				{
 					// Emit current span
 					FormatSpan span;
-					span.mBegin = inStr.AsCStr() + cursor;
-					span.mEnd	= inStr.AsCStr() + sequence_start;
+					span.mSpan	= inStr.SubStr(cursor, sequence_start - cursor);
 					span.mColor = current_color;
 					outSpans.PushBack(span);
 				}

--- a/src/Strings.cpp
+++ b/src/Strings.cpp
@@ -96,7 +96,7 @@ WStringView gUtf8ToWideChar(StringView inString, Span<wchar_t> ioBuffer)
 }
 
 
-void gPreprocessStringViewFormatting(StringView inStr, Vector<FormatSpan>& outSpans)
+void gParseANSIColors(StringView inStr, Vector<FormatSpan>& outSpans)
 {
 	int					  cursor		= 0;
 	Optional<FormatColor> current_color = Optional<FormatColor>();

--- a/src/Strings.cpp
+++ b/src/Strings.cpp
@@ -147,8 +147,8 @@ void gParseANSIColors(StringView inStr, Vector<FormatSpan>& outSpans)
 
 				// Parse ANSI escape sequence
 
-				Vector<long> numbers;
-				char*		 parse_end;
+				TempVector<long> numbers;
+				char*			 parse_end;
 				do
 				{
 					long parsed_number = strtol(inStr.AsCStr() + cursor, &parse_end, 10);

--- a/src/Strings.cpp
+++ b/src/Strings.cpp
@@ -186,42 +186,44 @@ void gParseANSIColors(StringView inStr, Vector<FormatSpan>& outSpans)
 				{
 					// regular / old style style specifiers
 
-					int num_idx = 0;
-					switch (numbers[num_idx++])
+					for (int num_idx = 0; num_idx < numbers.Size(); ++num_idx)
 					{
-					case 0:	 // reset all styles
-						current_color = {};
-						break;
-					case 30: // black
-						current_color = FormatColor{ .r = 0, .g = 0, .b = 0 };
-						break;
-					case 31: // red
-						current_color = FormatColor{ .r = 255, .g = 0, .b = 0 };
-						break;
-					case 32: // green
-						current_color = FormatColor{ .r = 0, .g = 255, .b = 0 };
-						break;
-					case 33: // yellow
-						current_color = FormatColor{ .r = 255, .g = 255, .b = 0 };
-						break;
-					case 34: // blue
-						current_color = FormatColor{ .r = 0, .g = 0, .b = 255 };
-						break;
-					case 35: // magenta
-						current_color = FormatColor{ .r = 255, .g = 0, .b = 255 };
-						break;
-					case 36: // cyan
-						current_color = FormatColor{ .r = 0, .g = 255, .b = 255 };
-						break;
-					case 37: // white
-						current_color = FormatColor{ .r = 255, .g = 255, .b = 255 };
-						break;
-					case 39: // default color
-						current_color = {};
-						break;
-					default:
-						// Unhandled command
-						break;
+						switch (numbers[num_idx])
+						{
+						case 0:	 // reset all styles
+							current_color = {};
+							break;
+						case 30: // black
+							current_color = FormatColor{ .r = 0, .g = 0, .b = 0 };
+							break;
+						case 31: // red
+							current_color = FormatColor{ .r = 255, .g = 0, .b = 0 };
+							break;
+						case 32: // green
+							current_color = FormatColor{ .r = 0, .g = 255, .b = 0 };
+							break;
+						case 33: // yellow
+							current_color = FormatColor{ .r = 255, .g = 255, .b = 0 };
+							break;
+						case 34: // blue
+							current_color = FormatColor{ .r = 0, .g = 0, .b = 255 };
+							break;
+						case 35: // magenta
+							current_color = FormatColor{ .r = 255, .g = 0, .b = 255 };
+							break;
+						case 36: // cyan
+							current_color = FormatColor{ .r = 0, .g = 255, .b = 255 };
+							break;
+						case 37: // white
+							current_color = FormatColor{ .r = 255, .g = 255, .b = 255 };
+							break;
+						case 39: // default color
+							current_color = {};
+							break;
+						default:
+							// Unhandled command
+							break;
+						}
 					}
 				}
 
@@ -289,6 +291,14 @@ REGISTER_TEST("gParseANSIColors")
 	TEST_TRUE(spans[0].mColor->r == 0 && spans[0].mColor->g == 255 && spans[0].mColor->b == 0);
 	TEST_TRUE(spans[1].mSpan.Begin() == test.Begin() + 20);
 	TEST_TRUE(spans[1].mColor->r == 0 && spans[1].mColor->g == 0 && spans[1].mColor->b == 255);
+	spans.Clear();
+
+	test = "\x1b[1;35mBold magenta text, except we don't support bold so ignored\x1b[0m";
+	gParseANSIColors(test, spans);
+	TEST_TRUE(spans.Size() == 1);
+	TEST_TRUE(spans[0].mSpan.Begin() == test.Begin() + 7);
+	TEST_TRUE(spans[0].mColor.has_value());
+	TEST_TRUE(spans[0].mColor->r == 255 && spans[0].mColor->g == 0 && spans[0].mColor->b == 255);
 	spans.Clear();
 
 	test = "\x1b[0mEscape sequence but no colors";

--- a/src/Strings.h
+++ b/src/Strings.h
@@ -197,4 +197,5 @@ struct FormatSpan
 	Optional<FormatColor> mColor;
 };
 
-void gPreprocessStringViewFormatting(StringView inStr, Vector<FormatSpan>& outSpans);
+// Parse the string for ANSI escape sequences with color codes
+void gParseANSIColors(StringView inStr, Vector<FormatSpan>& outSpans);

--- a/src/Strings.h
+++ b/src/Strings.h
@@ -7,6 +7,7 @@
 
 #include "Core.h"
 
+#include <optional>
 #include <string_view>
 
 #include <Strings.h>
@@ -183,3 +184,17 @@ bool gStringViewToEnum(StringView inStrValue, taEnumType& outValue)
 
 	return false;
 }
+
+struct FormatColor
+{
+	uint8 r, g, b;
+};
+
+struct FormatSpan
+{
+	const char*			  mBegin = nullptr;
+	const char*			  mEnd	 = nullptr;
+	Optional<FormatColor> mColor;
+};
+
+void gPreprocessStringViewFormatting(StringView inStr, Vector<FormatSpan>& outSpans);

--- a/src/Strings.h
+++ b/src/Strings.h
@@ -192,8 +192,7 @@ struct FormatColor
 
 struct FormatSpan
 {
-	const char*			  mBegin = nullptr;
-	const char*			  mEnd	 = nullptr;
+	StringView			  mSpan;
 	Optional<FormatColor> mColor;
 };
 

--- a/src/UI.cpp
+++ b/src/UI.cpp
@@ -1122,9 +1122,31 @@ void gDrawSelectedCookingLogEntry()
 		// If it's finished cooking, it's safe to read the log output.
 		if (log_entry.mCookingState.Load() > CookingState::Cooking)
 		{
-			//ImGui::PushTextWrapPos();
-			ImGui::TextUnformatted(log_entry.mOutput);
-			//ImGui::PopTextWrapPos();
+			if (log_entry.mOutputFormatSpans.Empty())
+			{
+				//ImGui::PushTextWrapPos();
+				ImGui::TextUnformatted(log_entry.mOutput);
+				//ImGui::PopTextWrapPos();
+			}
+			else
+			{
+				for (const FormatSpan& format_span : log_entry.mOutputFormatSpans)
+				{
+					if (format_span.mColor.has_value())
+					{
+						FormatColor color = format_span.mColor.value();
+						ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(color.r / 255.0f, color.g / 255.0f, color.b / 255.0f, 1.0f));
+					}
+
+					ImStrv span_text = { format_span.mBegin, format_span.mEnd };
+					ImGui::TextUnformatted(span_text);
+
+					if (format_span.mColor.has_value())
+					{
+						ImGui::PopStyleColor();
+					}
+				}
+			}
 		}
 	}
 	ImGui::EndChild();

--- a/src/UI.cpp
+++ b/src/UI.cpp
@@ -1138,8 +1138,7 @@ void gDrawSelectedCookingLogEntry()
 						ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(color.r / 255.0f, color.g / 255.0f, color.b / 255.0f, 1.0f));
 					}
 
-					ImStrv span_text = { format_span.mBegin, format_span.mEnd };
-					ImGui::TextUnformatted(span_text);
+					ImGui::TextUnformatted(format_span.mSpan);
 
 					if (format_span.mColor.has_value())
 					{


### PR DESCRIPTION
This is a pull request for #36.

We only calculate formatting once, when the command is done, as you suggested in the issue thread. We also effectively skip all of the color stuff if there are no ANSI codes in the log, which is probably a pretty common case for many users. The parsing took me a few attempts to get right but I think it strikes a good balance of simple, useful, and fast. It's flexible enough that it'd not be a pain to add support for more sequences/modes if wanted. (I've actually only tested the rgb color mode though, as that's what all my tools output, via the fmtlib color API).

I tried to follow the coding style & formatting as best as I could, but let me know if there's something I can fix. I'm a little unsure about the formatting but what I committed is what Visual Studio + clang-format did automatically so should hopefully be right?

// Simon